### PR TITLE
Add leading plus to positive bonuses and improve tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /packs
 /dist
 /unpacked
+/enhancedcombathud
+/enhancedcombathud-dnd5e
 
-*.iml
 GEMINI.md
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
-Requires Argon Core HUD to be installed
+# Argon Combat HUD extension for Rolemaster Unified (RMU)
 
-Software and associated documentation files in this repository are covered by an [MIT License](LICENSE.md).
+This project is a Foundry VTT module that integrates the "Argon - Combat HUD" module with the "Rolemaster Unified" (RMU) system. Its purpose is to provide a customized combat HUD for RMU that displays system-specific information and actions.
+
+The module is written in JavaScript and uses the Foundry VTT API, the Argon Core HUD API and the RMU API.
+
+## Features
+Key features include:
+
+*   A customised portrait panel showing HP, Power Points, and Defensive Bonus and with buttons to open character sheet and to roll initiative.
+*   Integration with the RMU movement system.
+*   Categorised attack buttons for Melee, Ranged, Natural, and Shield attacks.
+*   Panels for Resistance Rolls, Skill Rolls, and Endurance Checks (Physical/Mental).
+*   A "Rest" button to open the RMU rest dialog.
+*   A search tool for skills. Just start typing and it will show any skills matching your text and the number of skillsfound on the right of the search bar. Click the clear icon in the search bar to reset the filter. There is a favourites toggle which will, when active, will only show skills marked as your favourites.
+*   A combat panel to end turn when in combat.
+
+It lets players and the GM do many actions without opening the character or creature sheet. Each action button has a rich tooltip showing the same data available in the sheet.
+
+| Version   | Changes |
+| :--- | :--- |
+| **0.4.4** | *   Added leading + to positive bonus values<br>*   Added tooltips to Endurance buttons |
+| **0.4.3** | *   Minor CSS change to consolidate styles |
+| **0.4.2** | *   Added favourite toggle in the skills search bar<br>*   Added a favourite “chip” on all skill buttons that are marked as favourite on the actor skills tab |
+| **0.4.1** | *   Added combat panel with an end turn button visible only when the token is in combat and it is their turn<br>*   Fixed missing CSS styles for skill category buttons introduced in v0.4.0<br>*   Verified roll initiative button works (in portrait panel)<br>*   Changed clear icon in the skills search bar and made it visible only when there is a filter applied |
+| **0.4.0** | Code and CSS refactor |
+| **0.3.2** | Minor code cleanup |
+| **0.3.1** | The REST button now hides during combat (still accessible via the character sheet) |
+| **0.3.0** | *   Added skill manoeuvre rolls (found in the skills panel on the bottom bar; expand a category to see its skills)<br>*   Added a custom search bar to find skills (shows matches count; clear icon resets filter)<br>*   Added endurance rolls (physical and mental)<br>*   Updated several icons |
+| **0.2.0** | Includes attack buttons, resistance rolls, and the rest action |
+
+
+## Roadmap
+*   Spells (waiting on a system dependency)
+*   Items (waiting on a system dependency)
+*   Movement improvements to account for phased combat, show smaller units (1'), add additional colour breaks to allow for walk, jog, run, sprint and dash

--- a/index.js
+++ b/index.js
@@ -54,6 +54,35 @@ const STAR_ICON = MOD_ICON("star.svg");
 const RMUUtils = {
 
   /**
+   * Formats a number as a string with a leading plus sign for positive values.
+   * @param {any} n - The value to format.
+   * @returns {string} The formatted number string, or original value if not a number.
+   */
+  formatBonus(n) {
+    if (n === null || n === undefined) return n;
+    const s = String(n).trim();
+    if (s === '') return s; // Return trimmed string if empty
+    const num = Number(s);
+    if (isNaN(num)) return n; // Return original if not a number (e.g. "Yes")
+    return num > 0 ? `+${num}` : String(num);
+  },
+
+  /**
+   * Formats tooltip detail values, adding a leading plus sign to positive numbers.
+   * @param {Array<object>} details - The array of {label, value} pairs.
+   * @returns {Array<object>} The formatted array.
+   */
+  formatTooltipDetails(details) {
+    const excludedLabels = ["Ranks", "Total ranks", "Culture ranks", "Fumble"];
+    return details.map(detail => {
+      if (excludedLabels.includes(detail.label)) {
+        return detail;
+      }
+      return { ...detail, value: this.formatBonus(detail.value) };
+    });
+  },
+  
+  /**
    * Mounts a translucent overlay containing a number and label inside an action button.
    * This is used to display the total bonus for skills and resistances.
    * @param {HTMLElement} buttonEl - The root button element.
@@ -88,7 +117,7 @@ const RMUUtils = {
     if (number !== "" && number !== null && number !== undefined) {
       const n = document.createElement("div");
       n.className = "rmu-value-overlay-number";
-      n.textContent = String(number);
+      n.textContent = this.formatBonus(number);
       txt.appendChild(n);
     }
 
@@ -755,7 +784,7 @@ function defineAttacksMain(CoreHUD) {
         { label: "Total OB",         value: a.totalBonus }
       ].filter(x => x.value !== undefined && x.value !== null && x.value !== "");
 
-      return { title: this.label, subtitle: a.skill?.name ?? "", details };
+      return { title: this.label, subtitle: a.skill?.name ?? "", details: RMUUtils.formatTooltipDetails(details) };
     }
 
     /* ───────── Clicks ───────── */
@@ -920,10 +949,10 @@ function defineResistancesMain(CoreHUD) {
 
       const subtitle = [
         r.statShortName ? r.statShortName.toUpperCase() : null,
-        (r.total != null ? `Total ${r.total}` : null)
+        (r.total != null ? `Total ${RMUUtils.formatBonus(r.total)}` : null)
       ].filter(Boolean).join(" · ");
 
-      return { title: this.label, subtitle, details };
+      return { title: this.label, subtitle, details: RMUUtils.formatTooltipDetails(details) };
     }
 
     async _renderInner() {
@@ -1357,7 +1386,7 @@ function defineSkillsMain(CoreHUD) {
         { label: "Knack",            value: sys._knack },
         { label: "Total bonus",      value: sys._bonus }
       ].filter(x => x.value !== undefined && x.value !== null && x.value !== "");
-      return { title: this.label, subtitle: sys.category ?? "", details };
+      return { title: this.label, subtitle: sys.category ?? "", details: RMUUtils.formatTooltipDetails(details) };
     }
 
     async _renderInner() {
@@ -1514,10 +1543,19 @@ function defineSpecialChecksMain(CoreHUD) {
     async getTooltipData() {
       const sys = this._skill?.system ?? {};
       const details = [
-        // Omitted for brevity, assumed to be same as full skill tooltip logic
-        { label: "Roll Type", value: "Body Development (Endurance)" }
+        { label: "Name",             value: sys.name },
+        { label: "Specialization",   value: sys.specialization },
+        { label: "Category",         value: sys.category },
+        { label: "Total ranks",      value: sys._totalRanks },
+        { label: "Rank bonus",       value: sys._rankBonus },
+        { label: "Culture ranks",    value: sys.cultureRanks },
+        { label: "Stat",             value: sys.stat },
+        { label: "Stat bonus",       value: sys._statBonus },
+        { label: "Prof bonus",       value: sys._professsionalBonus },
+        { label: "Knack",            value: sys._knack },
+        { label: "Total bonus",      value: sys._bonus }
       ].filter(x => x.value !== undefined && x.value !== null && x.value !== "");
-      return { title: this.label, subtitle: sys.category ?? "Endurance Check", details };
+      return { title: this.label, subtitle: sys.category ?? "Endurance Check", details: RMUUtils.formatTooltipDetails(details) };
     }
 
     async _renderInner() {
@@ -1562,10 +1600,19 @@ function defineSpecialChecksMain(CoreHUD) {
     async getTooltipData() {
       const sys = this._skill?.system ?? {};
       const details = [
-        // Omitted for brevity, assumed to be same as full skill tooltip logic
-        { label: "Roll Type", value: "Mental Focus (Concentration)" }
+        { label: "Name",             value: sys.name },
+        { label: "Specialization",   value: sys.specialization },
+        { label: "Category",         value: sys.category },
+        { label: "Total ranks",      value: sys._totalRanks },
+        { label: "Rank bonus",       value: sys._rankBonus },
+        { label: "Culture ranks",    value: sys.cultureRanks },
+        { label: "Stat",             value: sys.stat },
+        { label: "Stat bonus",       value: sys._statBonus },
+        { label: "Prof bonus",       value: sys._professsionalBonus },
+        { label: "Knack",            value: sys._knack },
+        { label: "Total bonus",      value: sys._bonus }
       ].filter(x => x.value !== undefined && x.value !== null && x.value !== "");
-      return { title: this.label, subtitle: sys.category ?? "Concentration Check", details };
+      return { title: this.label, subtitle: sys.category ?? "Concentration Check", details: RMUUtils.formatTooltipDetails(details) };
     }
 
     async _renderInner() {

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "title": "Argon - Combat HUD (RMU)",
     "description": "Rolemaster Unified System Argon integration",
     "id": "enhancedcombathud-rmu",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "authors": [
         { "name": "Bob Morris (system integration)" },
         { "name": "Ken Dearman (system integration)" }


### PR DESCRIPTION
Introduced RMUUtils.formatBonus to display a leading plus sign for positive bonus values throughout the HUD. Updated tooltip generation for attacks, resistances, skills, and special checks to use formatted bonus values and provide more detailed information. Updated README with feature list and changelog, incremented module version to 0.4.4, and adjusted .gitignore ordering.